### PR TITLE
docs: update docstrings and fix stale comments

### DIFF
--- a/custom_components/cup_component/api.py
+++ b/custom_components/cup_component/api.py
@@ -179,8 +179,8 @@ class API:
             "data": result["data"],
         }
 
-    def _clean_url(self, url: str):
-        """Removes extra slashes in a URL while ignoring those immediately following "://".
+    def _clean_url(self, url: str) -> str:
+        """Remove extra slashes in a URL while ignoring those immediately following "://".
 
         Args:
             url (str): The URL from which extra slashes need to be removed.
@@ -194,7 +194,18 @@ class API:
         return corrected_url
 
     def _calculate_images(self, data: dict[str, Any]) -> None:
-        """..."""
+        """Parse image data from the API response and group images by update type.
+
+        Iterates over the list of images returned by the Cup API and categorises each
+        image into one of the following buckets: major_updates, minor_updates,
+        patch_updates, other_updates, unknown, or up_to_date. The result is stored
+        in the instance attribute ``cache_images``.
+
+        Args:
+            data (dict[str, Any]): The raw payload returned by the Cup API, expected
+                to contain an ``images`` key holding a list of image objects.
+
+        """
 
         mapping: dict[str, str] = {
             "major": "major_updates",
@@ -233,7 +244,19 @@ class API:
         self.cache_images = new_images
 
     def _calculate_metrics(self) -> None:
-        """..."""
+        """Compute summary counters from the categorised image cache.
+
+        Reads ``cache_images`` (populated by ``_calculate_images``) and builds a
+        flat dictionary of integer counters for each update category. Two derived
+        metrics are also computed:
+
+        - ``monitored_images``: total number of images across all categories.
+        - ``updates_available``: number of images that have an update pending,
+          excluding images in the ``up_to_date`` and ``unknown`` categories.
+
+        The result is stored in the instance attribute ``cache_metrics``.
+
+        """
 
         new_metrics: dict[str, int] = {
             "major_updates": 0,

--- a/custom_components/cup_component/helper.py
+++ b/custom_components/cup_component/helper.py
@@ -1,17 +1,20 @@
-"""..."""
+"""Utility functions for the Cup Component integration."""
 
 from homeassistant.util import slugify
 
 
 def create_entity_id_name(input_string: str) -> str:
-    """
-    Creates a normalized entity ID name from a raw input string.
+    """Create a normalized entity ID name from a raw input string.
+
+    Splits the input at the first dot, lowercases the domain part, and
+    slugifies the entity name part using Home Assistant's ``slugify`` helper.
 
     Args:
-        raw_name: The raw input string to transform.
+        input_string (str): The raw entity ID string to normalise, expected to
+            contain at least one dot separator (e.g. ``"sensor.My Device Name"``).
 
     Returns:
-        The normalized entity ID name.
+        str: The normalized entity ID (e.g. ``"sensor.my_device_name"``).
     """
 
     # Split the string at the first "."

--- a/custom_components/cup_component/sensor.py
+++ b/custom_components/cup_component/sensor.py
@@ -143,7 +143,6 @@ class CupComponentSensor(CupComponentEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
-        # Set the last start time attribute
         if isinstance(self.coordinator, DataUpdateCoordinator):
             if self.entity_description.key in self.api.cache_images:
                 return {


### PR DESCRIPTION
## Summary

Fixes identified during code review — documentation only, no logic changed.

### Changes

**`api.py`**
- Added full Google Style docstring on `_calculate_images`
- Added full Google Style docstring on `_calculate_metrics`
- Added missing `-> str` return type hint on `_clean_url`

**`helper.py`**
- Replaced placeholder module docstring (`"""..."""`) with a proper description
- Fixed `Args` parameter name mismatch in `create_entity_id_name` (`raw_name` → `input_string`)

**`sensor.py`**
- Removed stale comment `# Set the last start time attribute` in `extra_state_attributes`