### PR TITLE
fix: fix missing and deprecated type hints

### DIFF
--- a/custom_components/cup_component/api.py
+++ b/custom_components/cup_component/api.py
@@ -179,8 +179,8 @@ class API:
             "data": result["data"],
         }
 
-    def _clean_url(self, url: str):
-        """Removes extra slashes in a URL while ignoring those immediately following "://".
+    def _clean_url(self, url: str) -> str:
+        """Remove extra slashes in a URL while ignoring those immediately following "://".
 
         Args:
             url (str): The URL from which extra slashes need to be removed.
@@ -194,7 +194,18 @@ class API:
         return corrected_url
 
     def _calculate_images(self, data: dict[str, Any]) -> None:
-        """..."""
+        """Parse image data from the API response and group images by update type.
+
+        Iterates over the list of images returned by the Cup API and categorises each
+        image into one of the following buckets: major_updates, minor_updates,
+        patch_updates, other_updates, unknown, or up_to_date. The result is stored
+        in the instance attribute ``cache_images``.
+
+        Args:
+            data (dict[str, Any]): The raw payload returned by the Cup API, expected
+                to contain an ``images`` key holding a list of image objects.
+
+        """
 
         mapping: dict[str, str] = {
             "major": "major_updates",
@@ -233,7 +244,19 @@ class API:
         self.cache_images = new_images
 
     def _calculate_metrics(self) -> None:
-        """..."""
+        """Compute summary counters from the categorised image cache.
+
+        Reads ``cache_images`` (populated by ``_calculate_images``) and builds a
+        flat dictionary of integer counters for each update category. Two derived
+        metrics are also computed:
+
+        - ``monitored_images``: total number of images across all categories.
+        - ``updates_available``: number of images that have an update pending,
+          excluding images in the ``up_to_date`` and ``unknown`` categories.
+
+        The result is stored in the instance attribute ``cache_metrics``.
+
+        """
 
         new_metrics: dict[str, int] = {
             "major_updates": 0,

--- a/custom_components/cup_component/button.py
+++ b/custom_components/cup_component/button.py
@@ -108,6 +108,6 @@ class CupComponentButton(CupComponentEntity, ButtonEntity):
         self.coordinator.async_update_listeners()
 
     @property
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         """Return whether the button is enabled."""
         return self._is_enabled

--- a/custom_components/cup_component/config_flow.py
+++ b/custom_components/cup_component/config_flow.py
@@ -79,7 +79,7 @@ class CupComponentdFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlowHandler:
         """Get the options flow for this handler."""
         return OptionsFlowHandler()
 

--- a/custom_components/cup_component/config_flow.py
+++ b/custom_components/cup_component/config_flow.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_NAME, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
@@ -79,7 +79,7 @@ class CupComponentdFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Get the options flow for this handler."""
         return OptionsFlowHandler()
 
@@ -144,7 +144,7 @@ async def _async_validate_input(
 class OptionsFlowHandler(OptionsFlow):
     """Options flow used to change configuration (options) of existing instance of integration."""
 
-    async def async_step_init(self, user_input=None) -> ConfigFlowResult:
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         if user_input is not None:  # we asked to validate values entered by user
             errors = await _async_validate_input(self.hass, user_input)
 

--- a/custom_components/cup_component/helper.py
+++ b/custom_components/cup_component/helper.py
@@ -1,17 +1,20 @@
-"""..."""
+"""Utility functions for the Cup Component integration."""
 
 from homeassistant.util import slugify
 
 
 def create_entity_id_name(input_string: str) -> str:
-    """
-    Creates a normalized entity ID name from a raw input string.
+    """Create a normalized entity ID name from a raw input string.
+
+    Splits the input at the first dot, lowercases the domain part, and
+    slugifies the entity name part using Home Assistant's ``slugify`` helper.
 
     Args:
-        raw_name: The raw input string to transform.
+        input_string (str): The raw entity ID string to normalise, expected to
+            contain at least one dot separator (e.g. ``"sensor.My Device Name"``).
 
     Returns:
-        The normalized entity ID name.
+        str: The normalized entity ID (e.g. ``"sensor.my_device_name"``).
     """
 
     # Split the string at the first "."

--- a/custom_components/cup_component/sensor.py
+++ b/custom_components/cup_component/sensor.py
@@ -143,7 +143,6 @@ class CupComponentSensor(CupComponentEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
-        # Set the last start time attribute
         if isinstance(self.coordinator, DataUpdateCoordinator):
             if self.entity_description.key in self.api.cache_images:
                 return {

--- a/custom_components/cup_component/sensor.py
+++ b/custom_components/cup_component/sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, List
+from typing import Any
 
 from homeassistant.components.sensor import (
     EntityCategory,
@@ -119,7 +119,7 @@ class CupComponentSensor(CupComponentEntity, SensorEntity):
     def native_value(self) -> StateType:
         """Return the state of the device."""
 
-        possible_keys: List[str] = [
+        possible_keys: list[str] = [
             "major_updates",
             "minor_updates",
             "monitored_images",


### PR DESCRIPTION
## Summary

Fixes all type hint issues identified during code review. No logic changed.

Base branch: `docs/update-docstrings`

### Changes

**`sensor.py`**
- Replaced deprecated `List[str]` from `typing` with native `list[str]` (Python 3.9+)
- Removed unused `List` import from `typing`

**`config_flow.py`**
- Added `ConfigEntry` type hint on `async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow`
- Added `dict[str, Any] | None` type hint on `async_step_init(user_input: dict[str, Any] | None = None) -> ConfigFlowResult`
- Added `ConfigEntry` to imports

**`button.py`**
- Added missing `-> bool` return type hint on `is_enabled` property