### PR TITLE
fix: replace debug log with exception log on catch-all in config_flow.py

### DIFF
--- a/custom_components/cup_component/config_flow.py
+++ b/custom_components/cup_component/config_flow.py
@@ -104,8 +104,8 @@ class CupComponentdFlowHandler(ConfigFlow, domain=DOMAIN):
         ) as err:
             _LOGGER.debug("Connection failed: %s", err)
             return {CONF_URL: "invalid_path"}
-        except Exception as err:
-            _LOGGER.debug("Unknown exception: %s", err)
+        except Exception:
+            _LOGGER.exception("Unexpected exception during connection attempt to %s", self._config[CONF_URL])
             return {CONF_URL: "unknown_error"}
 
         return {}


### PR DESCRIPTION
## Summary

Improves visibility of unexpected exceptions during the connection attempt in the config flow.

### Change

**`config_flow.py` — `_async_try_connect`**

Avant :
```python
except Exception as err:
    _LOGGER.debug("Unknown exception: %s", err)
    return {CONF_URL: "unknown_error"}
```

Après :
```python
except Exception:
    _LOGGER.exception("Unexpected exception during connection attempt to %s", self._config[CONF_URL])
    return {CONF_URL: "unknown_error"}
```

`_LOGGER.exception` logue au niveau `ERROR` et inclut automatiquement la traceback complète, sans avoir besoin de passer `err` en argument. Cela permet de diagnostiquer les erreurs inattendues sans les étouffer silencieusement.