### PR TITLE
chore: remove leftover dev URL comment in const.py

### DIFF
--- a/custom_components/cup_component/const.py
+++ b/custom_components/cup_component/const.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 DOMAIN = "cup_component"
 DEFAULT_NAME = "Cup server name"
 DEFAULT_URL = "http://<YOUR_IP>:8000"
-# DEFAULT_URL = "http://nipogi.local:8765"
 
 CONF_UPDATE_INTERVAL = "update_interval"
 


### PR DESCRIPTION
## Summary

Removes the leftover commented-out dev URL `http://nipogi.local:8765` from `const.py`. This line was a local development artefact and has no place in production code.