### PR TITLE
refactor: remove unused _last_calls and _is_enabled dead code

### DIFF
--- a/custom_components/cup_component/api.py
+++ b/custom_components/cup_component/api.py
@@ -20,8 +20,6 @@ from .exceptions import (
 class API:
     """Cup API Client."""
 
-    _last_calls: dict[str, datetime] = {}
-
     _logger: logging.Logger | None
     _session: Any = None
     _prefix: str = "/api/v3"

--- a/custom_components/cup_component/button.py
+++ b/custom_components/cup_component/button.py
@@ -80,8 +80,6 @@ class CupComponentButton(CupComponentEntity, ButtonEntity):
         raw_name: str = f"button.{name}_{description.key}"
         self.entity_id = create_entity_id_name(raw_name)
 
-        self._is_enabled = True  # Initial state is enabled
-
     async def async_press(self) -> None:
         """Press the button."""
 
@@ -103,8 +101,3 @@ class CupComponentButton(CupComponentEntity, ButtonEntity):
             _LOGGER.error("Unable to launch '%s' action: %s", action, result.get("data"))
 
         self.coordinator.async_update_listeners()
-
-    @property
-    def is_enabled(self) -> bool:
-        """Return whether the button is enabled."""
-        return self._is_enabled


### PR DESCRIPTION
## Summary

Removes two pieces of dead code identified during code review. No logic changed.

### Changes

**`api.py`**
- Suppression de l'attribut de classe `_last_calls: dict[str, datetime] = {}` déclaré mais jamais lu ni écrit.

**`button.py`**
- Suppression de `self._is_enabled = True` dans `__init__` (jamais modifié)
- Suppression de la propriété `is_enabled` qui retournait `True` en permanence et ne correspond pas à l'API standard HA (`ButtonEntity` utilise `available` pour gérer la disponibilité)