### PR TITLE
refactor: use urlparse instead of split to extract base URL in entity.py

### DIFF
--- a/custom_components/cup_component/entity.py
+++ b/custom_components/cup_component/entity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlparse, urlunparse
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -34,7 +36,9 @@ class CupComponentEntity(CoordinatorEntity[DataUpdateCoordinator[None]]):
     def device_info(self) -> DeviceInfo:
         """Return the device information of the entity."""
 
-        config_url = self.api.url.split("/api/v3/json")[0]
+        # Build the base URL (scheme + netloc only) from the API URL
+        parsed = urlparse(self.api.url)
+        config_url = urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
 
         return DeviceInfo(
             identifiers={(DOMAIN, self._server_unique_id)},


### PR DESCRIPTION
## Summary

Remplace le `.split()` fragile par `urllib.parse` pour extraire l'URL de base dans `device_info`.

### Problème

```python
config_url = self.api.url.split("/api/v3/json")[0]
```

Cette approche suppose que l'URL contient toujours `/api/v3/json`. Si ce n'est pas le cas (URL personnalisée, trailing slash, etc.), `split()` retourne la liste complète et `[0]` donne l'URL entière — ce qui n'est pas le comportement attendu.

### Correction

```python
parsed = urlparse(self.api.url)
config_url = urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
```

`urlparse` extrait proprement `scheme` et `netloc` (ex: `http://192.168.1.10:8000`), quelle que soit la structure du path. `urlunparse` reconstruit l'URL proprement sans dépendance au contenu du path.