### PR TITLE
refactor: remove redundant isinstance check on coordinator in sensor.py

### DIFF
--- a/custom_components/cup_component/sensor.py
+++ b/custom_components/cup_component/sensor.py
@@ -143,12 +143,11 @@ class CupComponentSensor(CupComponentEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
-        if isinstance(self.coordinator, DataUpdateCoordinator):
-            if self.entity_description.key in self.api.cache_images:
-                return {
-                    "images_list": json.dumps(
-                        self.api.cache_images[self.entity_description.key]
-                    )
-                }
+        if self.entity_description.key in self.api.cache_images:
+            return {
+                "images_list": json.dumps(
+                    self.api.cache_images[self.entity_description.key]
+                )
+            }
 
         return None


### PR DESCRIPTION
## Summary

Supprime la vérification `isinstance(self.coordinator, DataUpdateCoordinator)` dans `extra_state_attributes`, qui est redondante.

### Raison

`CupComponentSensor` hérite de `CupComponentEntity` qui hérite de `CoordinatorEntity[DataUpdateCoordinator[None]]`. `self.coordinator` est donc toujours un `DataUpdateCoordinator` par construction — le check `isinstance` ne peut jamais être `False` et n'apporte aucune valeur.