### PR TITLE
feat: add binary sensor support for updates availability (1)

### DIFF
--- a/custom_components/cup_component/__init__.py
+++ b/custom_components/cup_component/__init__.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-PLATFORMS = [Platform.SENSOR, Platform.BUTTON]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.BUTTON]
 
 type CupComponentConfigEntry = ConfigEntry[CupComponentData]
 

--- a/custom_components/cup_component/binary_sensor.py
+++ b/custom_components/cup_component/binary_sensor.py
@@ -1,0 +1,121 @@
+"""Support for Cup Component binary sensor entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import CONF_NAME
+
+from .entity import CupComponentEntity
+from .helper import create_entity_id_name
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+    from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+    from . import CupComponentConfigEntry, CupComponentData
+    from .api import CupApi
+
+PARALLEL_UPDATES = 1
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class CupComponentBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Class describing Cup Component binary sensor entities."""
+
+
+BINARY_SENSOR_TYPES: tuple[CupComponentBinarySensorEntityDescription, ...] = (
+    CupComponentBinarySensorEntityDescription(
+        key="updates_available",
+        translation_key="updates_available",
+        device_class=BinarySensorDeviceClass.UPDATE,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001 # pylint: disable=unused-argument
+    entry: CupComponentConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Cup Component binary sensor entities from a config entry.
+
+    Args:
+        hass (HomeAssistant): The Home Assistant instance.
+        entry (CupComponentConfigEntry): The config entry for this integration.
+        async_add_entities (AddConfigEntryEntitiesCallback): Callback to register new entities.
+
+    Returns:
+        None.
+
+    """
+    name = entry.data[CONF_NAME]
+    cup_data = entry.runtime_data
+
+    entities: list[CupComponentBinarySensor] = [
+        CupComponentBinarySensor(
+            cup_data,
+            name,
+            entry.entry_id,
+            description,
+        )
+        for description in BINARY_SENSOR_TYPES
+    ]
+
+    async_add_entities(entities, update_before_add=True)
+
+
+class CupComponentBinarySensor(CupComponentEntity, BinarySensorEntity):  # pyright: ignore[reportIncompatibleVariableOverride]
+    """Representation of a Cup Component binary sensor."""
+
+    entity_description: CupComponentBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        cup_data: CupComponentData,
+        name: str,
+        server_unique_id: str,
+        description: CupComponentBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize a Cup Component binary sensor.
+
+        Args:
+            cup_data (CupComponentData): Runtime data containing the API client and coordinator.
+            name (str): The human-readable name of the Cup server.
+            server_unique_id (str): The unique identifier of the config entry.
+            description (CupComponentBinarySensorEntityDescription): The entity description for this binary sensor.
+
+        """
+        api: CupApi = cup_data.api
+        coordinator: DataUpdateCoordinator[None] = cup_data.coordinator
+
+        super().__init__(api, coordinator, name, server_unique_id)
+        self.entity_description = description  # pyright: ignore[reportIncompatibleVariableOverride]
+        self._attr_unique_id = f"{self._server_unique_id}/{description.key}"
+
+        raw_name: str = f"binary_sensor.{name}_{description.key}"
+        self.entity_id = create_entity_id_name(raw_name)
+
+    @property
+    def is_on(self) -> bool | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        """Return true if at least one update is available.
+
+        Returns:
+            bool | None: True if updates are available, False otherwise, or None if data is unavailable.
+
+        """
+        value = self.api.cache_metrics.get("updates_available")
+
+        if value is None:
+            return None
+
+        return value > 0

--- a/custom_components/cup_component/icons.json
+++ b/custom_components/cup_component/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "binary_sensor": {
+      "updates_available": {
+        "default": "mdi:arrow-down-bold-circle-outline"
+      }
+    },
     "sensor": {
       "major_updates": {
         "default": "mdi:arrow-down-bold-circle-outline"

--- a/custom_components/cup_component/strings.json
+++ b/custom_components/cup_component/strings.json
@@ -24,6 +24,11 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "updates_available": {
+                "name": "Updates Available"
+            }
+        },
         "sensor": {
             "major_updates": {
                 "name": "Images with Major Updates",

--- a/custom_components/cup_component/translations/en.json
+++ b/custom_components/cup_component/translations/en.json
@@ -38,6 +38,11 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "updates_available": {
+                "name": "Updates available"
+            }
+        },
         "sensor": {
             "major_updates": {
                 "name": "Images with major updates",

--- a/custom_components/cup_component/translations/fr.json
+++ b/custom_components/cup_component/translations/fr.json
@@ -38,6 +38,11 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "updates_available": {
+                "name": "Mises à jour disponibles"
+            }
+        },
         "sensor": {
             "major_updates": {
                 "name": "Images avec des mises à jour majeures",


### PR DESCRIPTION
## Summary

Adds a new `binary_sensor` platform to the `cup_component` integration, exposing an "Updates available" boolean indicator per Cup server.

## Changes

- `binary_sensor.py`: new platform with a single `updates_available` entity (`BinarySensorDeviceClass.UPDATE`). Returns `True` if at least one Docker image has a pending update, `False` otherwise, `None` if data is not yet available.
- `__init__.py`: added `Platform.BINARY_SENSOR` to the `PLATFORMS` list.
- `icons.json`: added icon for `binary_sensor.updates_available`.
- `strings.json`: added entity name for `binary_sensor.updates_available`.
- `translations/en.json`, `translations/fr.json`: added translated entity names.

## User-facing change

A new binary sensor **"Updates available"** is created for each configured Cup server. It can be used directly in automations and alerts to trigger actions when Docker image updates are detected.
